### PR TITLE
Add sstExternalDomainName fof the custom url handling

### DIFF
--- a/sst.schema
+++ b/sst.schema
@@ -1713,6 +1713,14 @@ attributetype ( sstAttributeType:236
     SUBSTR caseIgnoreIA5SubstringsMatch
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{32} )
 
+attributetype ( sstAttributeType:237
+    NAME 'sstExternalDomainName'
+    DESC 'The external domain name for the spice url.'
+    EQUALITY caseIgnoreIA5Match
+    SUBSTR caseIgnoreIA5SubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{64}
+    SINGLE-VALUE )
+
 objectclass ( sstObjectClass:1
     NAME 'sstReseller'
     SUP top STRUCTURAL
@@ -1863,7 +1871,7 @@ objectclass ( sstObjectClass:21
     NAME 'sstVirtualizationNode'
     SUP top STRUCTURAL
     MUST ( sstNode ) 
-    MAY ( description ) )
+    MAY ( description $ sstExternalDomainName ) )
 
 objectclass ( sstObjectClass:22
     NAME 'sstGroupwareOXModule'


### PR DESCRIPTION
This makes it possible to set the custom url for the spice url in LDAP and not using the config as done here: https://github.com/FOSS-Cloud/vm-manager/pull/71